### PR TITLE
an update to support TXT RR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'netaddr'
+gem 'ipaddress'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Example Use:
       m.hostname = "yum.domain.com"
       m.cname = "yum101.domain.com"
     }
+    announce "CHECK: adding a txt to the domain"
+    dns.update { |m|
+      m.type = :txt
+      m.hostname = "yum.domain.com"
+      m.data = "some fun stuff"
+    }
     announce "CHECK: adding a reverse to the domain"
     dns.update { |m|
       m.type = :reverse
@@ -49,6 +55,11 @@ Example Use:
       m.type = :cname
       m.hostname = "yum.domain.com"
     }
+    announce "CHECK: removing a txt to the domain"
+    dns.remove { |m|
+      m.type = :txt
+      m.hostname = "yum.domain.com"
+    }
     announce "CHECK: removing a reverse to the domain"
     dns.remove { |m|
       m.type = :reverse
@@ -56,4 +67,4 @@ Example Use:
       m.address = "192.168.19.20"
       m.subnet = "192.168.19.0/24"
     }
-    
+

--- a/dns-update.gemspec
+++ b/dns-update.gemspec
@@ -19,8 +19,12 @@ Gem::Specification.new do |s|
   s.summary     = %q{A gem library used for dyanmic dns updates}
   s.description = %q{Provides a ruby wrapper for nsupdates and dynamic dns}
   s.license     = 'MIT'
-  s.files       = `git ls-files`.split("\n")
-  s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files       = [ '.gitignore', 'Gemfile', 'LICENSE', 'README.md', 'bin/.config.yaml',
+			'bin/dns', 'dns-update.gemspec', 'lib/dns-update.rb', 'lib/dns-update/dns.rb',
+			'lib/dns-update/error.rb', 'lib/dns-update/model.rb', 'lib/dns-update/nsupdate.rb',
+		       	'lib/dns-update/settings.rb', 'lib/dns-update/utils.rb', 'lib/dns-update/validate.rb',
+			'lib/dns-update/version.rb', 'tests/test.rb']
+  s.test_files  = [ 'tests/test.rb' ]
+  s.executables = [ 'dns' ]
   s.add_dependency 'netaddr'
 end

--- a/dns-update.gemspec
+++ b/dns-update.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.name        = 'dns-update'
   s.version     = DnsUpdate::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.date        = '2014-05-31'
-  s.authors     = ['Rohith Jayawardene']
+  s.date        = '2019-03-15'
+  s.authors     = ['Rohith Jayawardene', 'Michael Richardson']
   s.email       = 'gambol99@gmail.com'
   s.homepage    = 'http://rubygems.org/gems/dns-update'
   s.summary     = %q{A gem library used for dyanmic dns updates}

--- a/lib/dns-update/model.rb
+++ b/lib/dns-update/model.rb
@@ -7,8 +7,8 @@
 #
 module DnsUpdate
   class Model
-    attr_accessor :address, :domain, :zone, :hostname, :subnet 
-    attr_accessor :print_only, :ttl, :cname, :type, :operation
+    attr_accessor :address, :domain, :zone, :hostname, :subnet
+    attr_accessor :print_only, :ttl, :cname, :type, :operation, :data
 
     def initialize
       @print_only = false

--- a/lib/dns-update/nsupdate.rb
+++ b/lib/dns-update/nsupdate.rb
@@ -19,7 +19,7 @@ update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @mod
   <%- elsif @model.type == 'CNAME' -%>
 update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.cname %>
   <%- elsif @model.type == 'TXT' -%>
-update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> "<%= @model.data %>"
+update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.data %>
   <%- elsif @model.type == 'PTR' -%>
 update add <%= @model.address %> <%= @model.ttl %> <%= @model.type %> <%= @model.hostname %>
   <%- end -%>

--- a/lib/dns-update/nsupdate.rb
+++ b/lib/dns-update/nsupdate.rb
@@ -17,20 +17,24 @@ zone <%= @model.zone %>.
   <%- if @model.type == 'A' -%>
 update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.address %>
   <%- elsif @model.type == 'CNAME' -%>
-update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.cname %>          
-  <%- elsif @model.type == 'PTR' -%> 
-update add <%= @model.address %> <%= @model.ttl %> <%= @model.type %> <%= @model.hostname %>                  
+update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.cname %>
+  <%- elsif @model.type == 'TXT' -%>
+update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> "<%= @model.data %>"
+  <%- elsif @model.type == 'PTR' -%>
+update add <%= @model.address %> <%= @model.ttl %> <%= @model.type %> <%= @model.hostname %>
   <%- end -%>
 <%- else -%>
   <%- if @model.type == 'A' -%>
 update delete <%= @model.hostname %>. <%= @model.type %>
   <%- elsif @model.type == 'CNAME' -%>
-update delete <%= @model.hostname %>. <%= @model.type %>        
+update delete <%= @model.hostname %>. <%= @model.type %>
+  <%- elsif @model.type == 'TXT' -%>
+update delete <%= @model.hostname %>. <%= @model.type %>
   <%- elsif @model.type == 'PTR' -%>
-update delete <%= @model.address %>. <%= @model.type %>        
+update delete <%= @model.address %>. <%= @model.type %>
   <%- end -%>
 <%- end -%>
-show 
+show
 send
 EOF
     def nsupdate(model)

--- a/lib/dns-update/nsupdate.rb
+++ b/lib/dns-update/nsupdate.rb
@@ -16,6 +16,8 @@ zone <%= @model.zone %>.
 <%- if @model.operation == :update -%>
   <%- if @model.type == 'A' -%>
 update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.address %>
+  <%- elsif @model.type == 'AAAA' -%>
+update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.address %>
   <%- elsif @model.type == 'CNAME' -%>
 update add <%= @model.hostname %>. <%= @model.ttl %> <%= @model.type %> <%= @model.cname %>
   <%- elsif @model.type == 'TXT' -%>
@@ -25,6 +27,8 @@ update add <%= @model.address %> <%= @model.ttl %> <%= @model.type %> <%= @model
   <%- end -%>
 <%- else -%>
   <%- if @model.type == 'A' -%>
+update delete <%= @model.hostname %>. <%= @model.type %>
+  <%- elsif @model.type == 'AAAA' -%>
 update delete <%= @model.hostname %>. <%= @model.type %>
   <%- elsif @model.type == 'CNAME' -%>
 update delete <%= @model.hostname %>. <%= @model.type %>
@@ -50,7 +54,7 @@ EOF
       end
     end
 
-    private 
+    private
 
     def render_update(model)
       @model = model

--- a/lib/dns-update/settings.rb
+++ b/lib/dns-update/settings.rb
@@ -11,7 +11,7 @@ module DnsUpdate
         options[x]
       end
     end
-  
+
     def settings
       @settings
     end

--- a/lib/dns-update/utils.rb
+++ b/lib/dns-update/utils.rb
@@ -9,7 +9,7 @@ require 'netaddr'
 module DnsUpdate
   module Utils
 
-    Hostname_Regex   = /^(([[:alnum:]]|[[:alnum:]][a-zA-Z0-9\-]*[[:alnum:]])\.)*([[:alnum:]]|[[:alnum:]][A-Za-z0-9\-]*[[:alnum:]])$/
+    Hostname_Regex   = /^(([_[[:alnum:]]]|[_[[:alnum:]]][_a-zA-Z0-9\-]*[[:alnum:]])\.)*([[:alnum:]]|[[:alnum:]][_A-Za-z0-9\-]*[[:alnum:]])$/
     Domain_Regex     = /^[[:alnum:]]+([\-\.]{1}[[:alnum:]]+)*\.[[:alpha:]]{2,5}$/
 
     def check_hostname(hostname)

--- a/lib/dns-update/utils.rb
+++ b/lib/dns-update/utils.rb
@@ -27,6 +27,10 @@ module DnsUpdate
       fail "the address: #{address} is invalid" unless address? address
     end
 
+    def check_txt(data)
+      fail 'you have not specified the data for the txt' unless data
+    end
+
     def check_subnet(network)
       fail 'you have not specified the subnet' unless network
       fail "the subnet: #{network} is invalid" unless subnet? network
@@ -79,12 +83,13 @@ module DnsUpdate
       (parse_address(network).netmask_ext =~ /^(255\.){3}255$/).nil?
     end
 
-    def types 
+    def types
       {
         :record => 'A',
         :cname  => 'CNAME',
         :reverse => 'PTR',
-        :service => 'SRV'
+        :service => 'SRV',
+        :txt     => 'TXT'
       }
     end
 

--- a/lib/dns-update/utils.rb
+++ b/lib/dns-update/utils.rb
@@ -55,7 +55,15 @@ module DnsUpdate
     end
 
     def address?(address)
-      NetAddr::CIDR.create address rescue return false
+      begin
+        NetAddr::IPv6.parse address
+      rescue NetAddr::ValidationError
+        begin
+          NetAddr::IPv4.parse address
+        rescue NetAddr::ValidationError
+          return false
+        end
+      end
       true
     end
 
@@ -85,16 +93,16 @@ module DnsUpdate
     end
 
     def arpa(network)
-      NetAddr::CIDR.create(network).arpa.gsub(/\.$/, '').chomp
+      NetAddr::IPv4Net.parse(network).arpa.gsub(/\.$/, '').chomp
     end
 
     def parse_address(ipaddr)
       begin
-        NetAddr::CIDR.create ipaddr
+        NetAddr::IPv4Net.parse ipaddr
       rescue NetAddr::ValidationError => e
         raise e.message
       end
-    end 
+    end
 
     def validate_file(filename, writable = false)
       raise ArgumentError, 'you have not specified a file to check' unless filename

--- a/lib/dns-update/utils.rb
+++ b/lib/dns-update/utils.rb
@@ -86,6 +86,8 @@ module DnsUpdate
     def types
       {
         :record => 'A',
+        :aaaa   => 'AAAA',
+        :record6 => 'AAAA',
         :cname  => 'CNAME',
         :reverse => 'PTR',
         :service => 'SRV',

--- a/lib/dns-update/validate.rb
+++ b/lib/dns-update/validate.rb
@@ -10,7 +10,7 @@ module DnsUpdate
       check_hostname model.hostname
       check_address model.address
       check_ttl model.ttl
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 
@@ -18,7 +18,7 @@ module DnsUpdate
       check_hostname model.hostname
       check_cname model.cname
       check_ttl model.ttl
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 
@@ -26,7 +26,7 @@ module DnsUpdate
       check_hostname model.hostname
       check_txt model.data
       check_ttl model.ttl
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 
@@ -41,19 +41,19 @@ module DnsUpdate
 
     def validate_remove_record(model)
       check_hostname model.hostname
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 
     def validate_remove_cname(model)
       check_hostname model.hostname
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 
     def validate_remove_txt(model)
       check_hostname model.hostname
-      model.zone = domain(model.hostname)
+      model.zone ||= domain(model.hostname)
       model
     end
 

--- a/lib/dns-update/validate.rb
+++ b/lib/dns-update/validate.rb
@@ -22,6 +22,14 @@ module DnsUpdate
       model
     end
 
+    def validate_update_txt(model)
+      check_hostname model.hostname
+      check_txt model.data
+      check_ttl model.ttl
+      model.zone = domain(model.hostname)
+      model
+    end
+
     def validate_update_reverse(model)
       check_hostname model.hostname
       check_address model.address
@@ -38,6 +46,12 @@ module DnsUpdate
     end
 
     def validate_remove_cname(model)
+      check_hostname model.hostname
+      model.zone = domain(model.hostname)
+      model
+    end
+
+    def validate_remove_txt(model)
       check_hostname model.hostname
       model.zone = domain(model.hostname)
       model

--- a/lib/dns-update/validate.rb
+++ b/lib/dns-update/validate.rb
@@ -14,6 +14,14 @@ module DnsUpdate
       model
     end
 
+    def validate_update_aaaa(model)
+      check_hostname model.hostname
+      check_address model.address
+      check_ttl model.ttl
+      model.zone ||= domain(model.hostname)
+      model
+    end
+
     def validate_update_cname(model)
       check_hostname model.hostname
       check_cname model.cname

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -29,6 +29,15 @@ dns.update { |m|
   m.address = '192.168.19.20'
   m.ttl = 100
 }
+
+announce 'CHECK: adding a host with leading _ to the domain'
+dns.update { |m|
+  m.type = :record
+  m.hostname = '_yum101.dasblinkenled.org'
+  m.address = '192.168.19.20'
+  m.ttl = 100
+}
+
 announce 'CHECK: adding a cname to the domain'
 dns.update { |m|
   m.type = :cname

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -14,9 +14,9 @@ def announce(message)
 end
 
 options = {
-  :master     => '192.168.10.12',
-  :key_name   => 'rndc-key',
-  :secret     => './rndc.key',
+  :master     => '192.168.1.2',
+  :key_name   => 'hmac-sha256:keyname',
+  :secret     => 'stuff',
   :print_only => true
 }
 
@@ -25,40 +25,47 @@ dns = DnsUpdate::load options
 announce 'CHECK: adding a host to the domain'
 dns.update { |m|
   m.type = :record
-  m.hostname = 'yum101.domain.com'
+  m.hostname = 'yum101.dasblinkenled.org'
   m.address = '192.168.19.20'
   m.ttl = 100
 }
 announce 'CHECK: adding a cname to the domain'
 dns.update { |m|
   m.type = :cname
-  m.hostname = 'yum.domain.com'
-  m.cname = 'yum101.domain.com'
+  m.hostname = 'yum.dasblinkenled.org'
+  m.cname = 'yum101.dasblinkenled.org'
 }
+
+# BROKEN
+if false
 announce 'CHECK: adding a reverse to the domain'
 dns.update { |m|
   m.type = :reverse
-  m.hostname = 'yum.domain.com'
+  m.hostname = 'yum.dasblinkenled.org'
   m.address = '192.168.19.20'
   m.subnet = '192.168.19.0/24'
 }
+end
 
 # REMOVAL
 announce 'CHECK: removing a host to the domain'
 dns.remove { |m|
   m.type = :record
-  m.hostname = 'yum101.domain.com'
+  m.hostname = 'yum101.dasblinkenled.org'
 }
 
 announce 'CHECK: removing a cname to the domain'
 dns.remove { |m|
   m.type = :cname
-  m.hostname = 'yum.domain.com'
+  m.hostname = 'yum.dasblinkenled.org'
 }
+
+if false
 announce 'CHECK: removing a reverse to the domain'
 dns.remove { |m|
   m.type = :reverse
-  m.hostname = 'yum.domain.com'
+  m.hostname = 'yum.dasblinkenled.org'
   m.address = '192.168.19.20'
   m.subnet = '192.168.19.0/24'
 }
+end

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -36,6 +36,13 @@ dns.update { |m|
   m.cname = 'yum101.dasblinkenled.org'
 }
 
+announce "CHECK: adding a txt to the domain"
+dns.update { |m|
+  m.type = :txt
+  m.hostname = "yum101.dasblinkenled.org"
+  m.data = "some fun stuff"
+}
+
 # BROKEN
 if false
 announce 'CHECK: adding a reverse to the domain'
@@ -58,6 +65,12 @@ announce 'CHECK: removing a cname to the domain'
 dns.remove { |m|
   m.type = :cname
   m.hostname = 'yum.dasblinkenled.org'
+}
+
+announce "CHECK: removing a txt to the domain"
+dns.remove { |m|
+  m.type = :txt
+  m.hostname = "yum.domain.com"
 }
 
 if false

--- a/tests/test.rb
+++ b/tests/test.rb
@@ -38,6 +38,15 @@ dns.update { |m|
   m.ttl = 100
 }
 
+announce 'CHECK: adding a multi-part host to the domain, with zone set'
+dns.update { |m|
+  m.type = :record
+  m.zone     = 'dasblinkenled.org'
+  m.hostname = '_yum101.r.b.dasblinkenled.org'
+  m.address = '192.168.19.20'
+  m.ttl = 100
+}
+
 announce 'CHECK: adding a cname to the domain'
 dns.update { |m|
   m.type = :cname


### PR DESCRIPTION
This updates some of the ancient use of NetADDR::CIDR, incomplete, so reverse does not work.
But forward works, and now supports TXT RR for things like DNS-01 LetsEncrypt challenges.
